### PR TITLE
[Fix] 375px 내 좌우 스크롤 여백 수정

### DIFF
--- a/src/components/pages/recruit/ScheduleContent.tsx
+++ b/src/components/pages/recruit/ScheduleContent.tsx
@@ -36,12 +36,12 @@ export const ScheduleContent = () => {
           }
         >
           <div
-            className={`w-full max-[441px]:pr-7 max-[375px]:pl-7 flex flex-nowrap dt:gap-5 ph:gap-3 max-[375px]:w-full dt:max-w-[1230px] ph:overflow-x-auto dt:overflow-x-hidden ph:[&::-webkit-scrollbar]:hidden dt:[&::-webkit-scrollbar]:block`}
+            className={`w-full max-dt:pr-7 max-[375px]:pl-7 flex flex-nowrap dt:gap-5 ph:gap-3 max-[375px]:w-full dt:max-w-[1230px] ph:overflow-x-auto dt:overflow-x-hidden ph:[&::-webkit-scrollbar]:hidden dt:[&::-webkit-scrollbar]:block`}
           >
             {TrackData.map((track, index) => (
               <div
                 key={index}
-                className={`flex flex-col justify-end dt:w-[395px] dt:h-[508px] ph:w-[204px] ph:h-[253px] bg-gray9 text-white dt:rounded-[40px] ph:rounded-[25px] dt:pl-[58px] dt:pr-[57px] dt:pb-[58px] ph:px-6 ph:pb-[25px] box-border relative shrink-0 
+                className={`flex flex-col justify-end dt:w-[395px] dt:h-[508px] dt:ml-0 ph:w-[204px] ph:h-[253px] bg-gray9 text-white dt:rounded-[40px] ph:rounded-[25px] dt:pl-[58px] dt:pr-[57px] dt:pb-[58px] ph:px-6 ph:pb-[25px] box-border relative shrink-0 
                   ${index === 0 ? 'min-[375px]:ml-7' : ''}
                 `}
               >

--- a/src/components/pages/recruit/ScheduleContent.tsx
+++ b/src/components/pages/recruit/ScheduleContent.tsx
@@ -29,14 +29,14 @@ export const ScheduleContent = () => {
         </div>
         <span className="text-gray0 dt:subhead2 ph:subhead3">트랙 소개</span>
       </div>
-      <div className="flex dt:px-0 box-border justify-end max-[375px]:mx-7 min-[375px]:w-screen min-[441px]:w-full">
+      <div className="flex dt:px-0 box-border justify-end min-[360px]:w-screen min-[441px]:w-full">
         <div
           className={
             'flex flex-row dt:gap-5 ph:gap-2 dt:mt-[46px] ph:mt-2 dt:w-full max-[375px]:justify-between items-center w-full min-[375px]:w-full ml-auto'
           }
         >
           <div
-            className={`w-full max-[441px]:pr-7 flex flex-nowrap dt:gap-5 ph:gap-3 max-[375px]:max-w-[347px] dt:max-w-[1230px] ph:overflow-x-auto dt:overflow-x-hidden ph:[&::-webkit-scrollbar]:hidden dt:[&::-webkit-scrollbar]:block`}
+            className={`w-full max-[441px]:pr-7 max-[375px]:pl-7 flex flex-nowrap dt:gap-5 ph:gap-3 max-[375px]:w-full dt:max-w-[1230px] ph:overflow-x-auto dt:overflow-x-hidden ph:[&::-webkit-scrollbar]:hidden dt:[&::-webkit-scrollbar]:block`}
           >
             {TrackData.map((track, index) => (
               <div


### PR DESCRIPTION
## 📍 이슈 번호
- #3 

## 📎 작업 내용
### ✨ 375px 내 좌우 스크롤 여백 수정
- 375px 내 좌우 스크롤 여백 수정하였습니다.
- min-[375px]: ml-7 적용하면서 추가된 데스크탑 마진 삭제하였습니다.

## 📎 작업 화면 스크린샷
<img width="375" alt="스크린샷 2025-02-14 오후 8 15 04" src="https://github.com/user-attachments/assets/76497b84-221a-47b3-9aa4-7f87e9f9c4bf" />

